### PR TITLE
style: プロフィールページとプロフィール編集ページのレイアウトを最低限整えた fix #3

### DIFF
--- a/app/views/devise/registrations/profile_edit.html.slim
+++ b/app/views/devise/registrations/profile_edit.html.slim
@@ -1,11 +1,22 @@
-= form_for current_user, url: {action: 'profile_update'} do |f|
-  .field
-    = f.label :name
-    br
-    = f.text_field :name
-  .field
-    = f.label :self_introduction
-    br
-    = f.text_area :self_introduction
-  .actions
-    = f.submit "Update"
+.flex-col
+  .grid.h-screen.grid.grid-cols-6
+    main.col-span-5.bg-gray-300
+      p HOME
+      .flex.mx-auto.items-center.justify-center.shadow-lg.mt-100.mx-8.mb-4.max-w-lg
+        .w-full.max-w-xl.bg-white.rounded-lg.px-4.pt-2
+          .flex.flex-wrap.-mx-3.mb-6
+          
+            = form_for current_user, url: {action: 'profile_update'} do |f|
+              .field
+                = f.label :name
+                br
+                = f.text_field :name, class: "bg-gray-100 rounded border border-gray-400 leading-normal resize-none w-full py-2 px-3 font-medium placeholder-gray-700 focus:outline-none focus:bg-white"
+              .field
+                = f.label :self_introduction
+                br
+                = f.text_area :self_introduction, class: "bg-gray-100 rounded border border-gray-400 leading-normal resize-none w-full h-20 py-2 px-3 font-medium placeholder-gray-700 focus:outline-none focus:bg-white"
+              .actions
+                button.px-4.pt-3.pb-2.bg-white.text-gray-700.font-medium.py-1.px-4.border.border-gray-400.rounded-lg.tracking-wide.mr-1.hover:bg-gray-100
+                  =f.submit 'プロフィールを編集する'
+    = render partial: 'shared/side'
+  = render partial: 'shared/fotter'

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,20 +1,17 @@
-h1 
-  | About me
+.flex-col
+  .grid.h-screen.grid.grid-cols-6
+    main.col-span-5.bg-gray-300
+      p Profile
+      .flex.mx-auto.items-center.justify-center.shadow-lg.mt-100.mx-8.mb-4.max-w-lg
+        .w-full.max-w-xl.bg-white.rounded-lg.px-4.pt-2
+          .flex.flex-wrap.-mx-3.mb-6
+            
+            br = @user.name
+            br = @user.oicey_id
+            / br = @user.email
+            br = @user.self_introduction
 
-h2 OiceyID
-p = @user.oicey_id
-
-h2 ユーザー名
-p = @user.name
-
-h2 メールアドレス
-p = @user.email
-
-h2 自己紹介
-p = @user.self_introduction
-
-button.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
-  = link_to 'プロフィール編集', profile_edit_path(current_user) 
-    / edit_user_path(current_user)
-    / edit_user_registration_path
-      /  profile_edit_path(current_user)
+            button.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
+              = link_to 'プロフィール編集', profile_edit_path(current_user) 
+    = render partial: 'shared/side'
+  = render partial: 'shared/fotter'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,7 +9,6 @@ ja:
           has_many: "%{record}が存在しているので削除できません"
     models:
       post: ポスト
-      # user: ユーザー
     attributes:
       post:
           id: ID
@@ -18,6 +17,12 @@ ja:
           visit_day: 訪問日
           created_at: 投稿日時
           updated_at: 更新日時
+      user: ユーザー
+    attributes:
+      user:
+          id: ID
+          name: 名前
+          self_introduction: 自己紹介
   date:
     abbr_day_names:
     - 日


### PR DESCRIPTION
プロフィールボタンを押下するとプロフィールページに遷移し、上の方にメッセージが表示され、
![スクリーンショット 2021-01-15 21 48 18](https://user-images.githubusercontent.com/36786134/104729229-788c8100-577b-11eb-9a75-f038ffaa88ac.png)

正しく変更されていることが確認できた。
![スクリーンショット 2021-01-15 21 48 26](https://user-images.githubusercontent.com/36786134/104729232-79bdae00-577b-11eb-8189-1a1866dcd7e8.png)
