### PR TITLE
feat:いいね機能の実装のためにコントローラーとビューを作成

### DIFF
--- a/app/assets/javascripts/likes.coffee
+++ b/app/assets/javascripts/likes.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/likes.scss
+++ b/app/assets/stylesheets/likes.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the likes controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,16 @@
+class LikesController < ApplicationController
+  def create
+    # like.user_id = current_user.idが済んだ状態で生成される。bulidはnewと同じ意味。アソシエーションしながらインスタンスをnewするときに使われるらしい。
+    like = current_user.likes.build(post_id: params[:post_id])
+    like.save
+    redirect_to posts_path
+  end
+
+  def destroy
+    like = Like.find_by(post_id: params[:post_id], user_id: current_user.id)
+    like.destroy
+    redirect_to posts_path
+
+  end
+
+end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -7,6 +7,7 @@ class LikesController < ApplicationController
   end
 
   def destroy
+    # find_byでpost_idとuser_idを複数検索をし、一致したものを削除し、投稿一覧ページに戻る。
     like = Like.find_by(post_id: params[:post_id], user_id: current_user.id)
     like.destroy
     redirect_to posts_path

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,8 @@ class UsersController < ApplicationController
     @set_relationship = current_user.relationships.new
     # 自身の投稿一覧
     @myposts = current_user.posts.all
+    # ユーザーがいいねした投稿を取得
+    @like_posts = @user.like_posts
   end
 
   # フォローしている人を取得（フォロー）。気になるした人っていう使い方もできそう。

--- a/app/helpers/likes_helper.rb
+++ b/app/helpers/likes_helper.rb
@@ -1,0 +1,2 @@
+module LikesHelper
+end

--- a/app/views/likes/_like.html.slim
+++ b/app/views/likes/_like.html.slim
@@ -1,0 +1,10 @@
+- if post.liked_by?(current_user)
+  = link_to 'お気に入り解除:', post.likes.count, post_likes_path(post.id), method: :delete 
+- else
+  = link_to 'お気に入り登録:', post.likes.count, post_likes_path(post.id), method: :post, remote: true
+                  / - if current_user
+                  /   - if post.liked_by?(current_user)
+                  /     td= link_to 'お気に入り解除:', post.likes.count, post_likes_path(post.id), method: :delete 
+                  /   - else 
+                  /     td= link_to 'お気に入り登録:', post.likes.count, post_likes_path(post.id), method: :post 
+                  / td

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -12,11 +12,12 @@
                   / td= render partial: 'likes/_like', post: post
                   - if user_signed_in?
                     - if post.liked_by?(current_user)
-                      = link_to 'いいね済み:', post_likes_path(post.id), method: :delete
+                      td= link_to 'いいね済み', post_likes_path(post.id), method: :delete
+                      td= post.likes.count
                       / , post.likes.count
                     - else 
-                      = link_to 'いいね:', post_likes_path(post.id), method: :post
-                      / , post.likes.count
+                      td= link_to 'いいね', post_likes_path(post.id), method: :post
+                      td= post.likes.count
                   td
                   - if current_user.id == post.user_id
                     button.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -9,12 +9,15 @@
                 tr
                   td= link_to post.body ,post_path(post)
                   td= post.visit_day
-                    / - if current_user
-                  / - if post.favorited_by?(current_user)
-                  /   td= link_to 'お気に入り解除:', post.favorites.count, post_favorites_path(post.id), method: :delete 
-                  / - else 
-                  /   td= link_to 'お気に入り登録:', post.favorites.count, post_favorites_path(post.id), method: :post 
-                  / td
+                  / td= render partial: 'likes/_like', post: post
+                  - if user_signed_in?
+                    - if post.liked_by?(current_user)
+                      = link_to 'いいね済み:', post_likes_path(post.id), method: :delete
+                      / , post.likes.count
+                    - else 
+                      = link_to 'いいね:', post_likes_path(post.id), method: :post
+                      / , post.likes.count
+                  td
                   - if current_user.id == post.user_id
                     button.bg-blue-500.hover:bg-blue-700.text-white.font-bold.py-2.px-4.rounded
                       = link_to '編集', edit_post_path(post)

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -42,6 +42,11 @@
                   .-mr-2.px-4.pt-4.pb-5.text-right
                     button.bg-red-500.hover:bg-red-700.text-white.font-bold.py-2.px-4.rounded
                       = link_to '削除', myposts, method: :delete, remote: true, data: { confirm: "投稿を削除します。よろしいですか？" }
-              
+
+      / .flex.mx-auto.items-center.justify-center.shadow-lg.mt-100.mx-10.mb-4.max-w-lg
+      /   .w-full.max-w-xl.bg-white.rounded-lg.px-4
+      /     p いいね一覧
+      /     - @likes.each do |like|
+            
     = render partial: 'shared/side'
   = render partial: 'shared/fotter'

--- a/spec/controllers/likes_controller_spec.rb
+++ b/spec/controllers/likes_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe LikesController, type: :controller do
+
+end

--- a/spec/helpers/likes_helper_spec.rb
+++ b/spec/helpers/likes_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the LikesHelper. For example:
+#
+# describe LikesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe LikesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
いいねボタンを押すといいね済みとなるようになった。
いいね数をカウントさせる処理とマイページで自分がいいねした投稿を一覧表示できるようにします。