### PR TITLE
feat: 通知機能の実装 fix #10

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -3,6 +3,8 @@ class LikesController < ApplicationController
     # like.user_id = current_user.idが済んだ状態で生成される。bulidはnewと同じ意味。アソシエーションしながらインスタンスをnewするときに使われるらしい。
     like = current_user.likes.build(post_id: params[:post_id])
     like.save
+    
+    post = Post.find(params[:post_id])
     # いいねが押されたタイミングで通知レコードを作成する
     post.create_notification_like!(current_user)
     redirect_to posts_path

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -8,7 +8,7 @@ class RelationshipsController < ApplicationController
     
     if following.save
       # フォローしたタイミングで通知レコードを作成する
-      following.create_notification_follow!(current_user)
+      @user.create_notification_follow!(current_user)
       redirect_to @user, notice: 'きになるしました！'
     else
       redirect_to @user, notice: 'きになるに失敗しました…'

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -44,10 +44,10 @@ class Post < ApplicationRecord
     # 自分以外にコメントしている人をすべて取得し、全員に通知を送る
     commentd_ids = Comment.select(:user_id).where(post_id: id).where.not(user_id: current_user.id).distinct
     commentd_ids.each do |commentd_id|
-      save_notification_comment!(current_user, comment_id, temp_id['user_id'])
+      save_notification_comment!(current_user, comment_id, commentd_id['user_id'])
     end
     # まだ誰もコメントしていない場合は、投稿者に通知を送る
-    save_notification_comment!(current_user, comment_id, user_id) if temp_ids.blank?
+    save_notification_comment!(current_user, comment_id, user_id) if commentd_ids.blank?
   end
 
   # 複数通知、自分自身へのコメントの通知を通知済みにする

--- a/app/views/notifications/_notification.html.slim
+++ b/app/views/notifications/_notification.html.slim
@@ -1,0 +1,41 @@
+- visitor = notification.visitor
+- visited = notification.visited
+.col-md-6.mx-auto
+  .form-inline
+    span
+      = link_to profile_user_path(visitor) do
+        / = image_tag avatar_url(visitor).to_s
+        / , class: "icon_mini"
+        strong
+          = visitor.name
+      
+
+      - case notification.action
+      - when 'follow' then
+        = 'さんに'
+        = "きになる!されました"
+      - when 'like' then
+        = 'さんが'
+        = link_to 'あなたの投稿', notification.post
+        / , style: "font-weight: bold;"
+        
+        = "いいねしました"
+      - when 'comment' then
+        = 'さんが'
+        - if notification.post.user_id == visited.id
+          = link_to "あなたの投稿", notification.post
+          / , style: "font-weight: bold;"
+        - else
+          span
+            = link_to post_path(notification.post) do
+              = image_tag avatar_url(notification.post.user).to_s
+              / , class: "icon_mini" 
+              strong
+                = notification.post.user.name + 'さんの投稿'
+        = "コメントしました"
+        p.text-muted.mb-0
+          = Comment.find_by(id: notification.comment_id)&.comment
+
+  .small.text-muted.text-right
+    = time_ago_in_words(notification.created_at).upcase
+  hr

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -1,0 +1,11 @@
+/ 自分の投稿に対するいいね、コメントは通知に表示しない
+- notifications = @notifications.where.not(visitor_id: current_user.id)
+- if notifications.exists?
+  = render notifications
+    / = paginate notifications
+- else
+  p
+    | 通知はありません
+
+= render partial: 'shared/side'
+= render partial: 'shared/fotter'

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -3,6 +3,7 @@
         li = link_to 'Oicey', root_path
         - if user_signed_in?
           li = link_to 'プロフィール',profile_user_path(current_user)
+          li = link_to '通知一覧',notifications_path(current_user)
           li = link_to 'ログアウト', destroy_user_session_path, method: :delete
           
         - else

--- a/app/views/shared/_side.html.slim
+++ b/app/views/shared/_side.html.slim
@@ -2,3 +2,4 @@ side.col-span-1.bg-yellow-500
     li = link_to '投稿一覧(HOME)', posts_path
     li = link_to '新規投稿', new_post_path
     li = link_to 'プロフィール', profile_user_path(current_user)
+    li = link_to '通知一覧',notifications_path(current_user)


### PR DESCRIPTION
いいね、コメント、きになる（フォロー）された時に通知一覧ページに通知が行くことを目視で確認。
コメントにコメントされた際の通知の確認はコメントにコメントする機能をつけていなかったので、実装次第追加します！
![スクリーンショット 2021-02-05 3 28 52](https://user-images.githubusercontent.com/36786134/106939034-11069780-6763-11eb-9e15-9376dc79a6d2.png)
